### PR TITLE
Added METASCOPES for compatibility and made env param optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ npx @adobe/reactor-downloader --env=production --private-key=/Users/jane/launchk
 
 The named parameters are as follows:
 
-##### --env
-
-The environment where the property exists. Valid options are `development`, `qe`, `integration`, and `production`. Users outside of Adobe will only use `production`.
-
 ##### --private-key (for authentication using an Adobe I/O integration)
 
 The local path (relative or absolute) to the RSA private key. Instructions on how to generate this key can be found in the [Getting Started guide](https://developer.adobelaunch.com/guides/extensions/getting-started/) and should have been used when creating your integration through the Adobe I/O console.
@@ -60,9 +56,9 @@ Your API key. You can find this on the overview screen for the integration you h
 
 Your client secret. You can find this on the overview screen for the integration you have created within the [Adobe I/O console](https://console.adobe.io).
 
-##### --access-token (for authentication using an access token)
+##### --env (for Adobe internal use only)
 
-A valid access token.
+The environment where the property exists. Valid options are `development`, `qe`, `integration`, and `production`. Users outside of Adobe do not have to use this flag.
 
 ##### --save
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -87,7 +87,7 @@ yargs
   }
 
   // get the environment
-  args.env == args.env || 'production'; // do not ask for it, people outside Adobe will never use it
+  args.env = args.env || 'production'; // do not ask for it, people outside Adobe will never use it
   const environments = {
     production: {
       name: 'production',

--- a/bin/index.js
+++ b/bin/index.js
@@ -87,27 +87,7 @@ yargs
   }
 
   // get the environment
-  if (!args.env) {
-    args.env = (await inquirer.prompt([{
-      type: 'list',
-      name: 'env',
-      message: 'To which environment would you like to download the property from?',
-      choices: [{
-        name: 'Production',
-        value: 'production',
-      }, {
-        name: 'Integration (Adobe Internal Use Only)',
-        value: 'integration',
-      }, {
-        name: 'QE (Adobe Internal Use Only)',
-        value: 'qe',
-      }, {
-        name: 'Development (Adobe Internal Use Only)',
-        value: 'development',
-      }],
-      default: 0
-    }])).env;
-  }
+  args.env == args.env || 'production'; // do not ask for it, people outside Adobe will never use it
   const environments = {
     production: {
       name: 'production',
@@ -191,7 +171,7 @@ yargs
     }])).clientSecret;
   }
 
-  // if we were passed a payload already, us that for authenticating...
+  // if we were passed a payload already, use that for authenticating...
   if (args.integration) {
 
     // getAccessToken
@@ -201,10 +181,11 @@ yargs
   // TODO: add other metascopes...
   } else {
     const METASCOPES = [
-      // 'ent_reactor_extension_developer_sdk',
-      // 'ent_reactor_admin_sdk',
       // 'ent_reactor_it_admin_sdk',
       'ent_reactor_sdk',
+      // the two following are needed for compatibility with integrations created before the ent_reactor_sdk metascope existed.
+      'ent_reactor_extension_developer_sdk',
+      'ent_reactor_admin_sdk',
     ];
     // try to get an access token using a few different metascopes
     for (let i = 0; i < METASCOPES.length; i++) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Two changes:
1. Added the two old METASCOPES back into the mix for compatibility with integrations created before the change
2. Made the `env` argument optional (defaulting to 'production'

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The reactor-downloader wouldn't work for me without the METASCOPES added.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
